### PR TITLE
[Session] Fix autotest failing right after midnight

### DIFF
--- a/src/test/java/seedu/address/model/session/InvalidStartEndTimeTest.java
+++ b/src/test/java/seedu/address/model/session/InvalidStartEndTimeTest.java
@@ -12,8 +12,10 @@ public class InvalidStartEndTimeTest {
 
     @Test
     public void constructor_invalidTime_throwsIllegalArgumentException() {
-        assertThrows(IllegalArgumentException.class, () -> new Session(LocalTime.now(),
-                LocalTime.now().minus(1, ChronoUnit.HOURS), LocalDate.now(),
+        LocalTime startTime = LocalTime.of(14, 00, 00);
+        LocalTime endTime = startTime.minus(1, ChronoUnit.HOURS);
+        LocalDate startDate = LocalDate.of(2020, 01, 01);
+        assertThrows(IllegalArgumentException.class, () -> new Session(startTime, endTime, startDate,
                 Session.SessionType.SESSION_TYPE_OTHER, ""));
     }
 }


### PR DESCRIPTION
## Session Autotest Failure Fix
Fix autotest failure when tests are run within an hour after midnight. Invalid `endTime` wraps backward an hour earlier causing it to become valid. The required assertion will no longer be thrown.

## Fix Details
Make the unit test "current-time" independent. `LocalTime` used during tests is now fixed to arbitrary values.