### PR TITLE
[Session] Add Session specific parsing classes

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -8,6 +8,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX = "The student index provided is invalid";
+    public static final String MESSAGE_INVALID_SESSION_DISPLAYED_INDEX = "The session index provided is invalid";
     public static final String MESSAGE_STUDENTS_LISTED_OVERVIEW = "%1$d students listed!";
 
 }

--- a/src/main/java/seedu/address/logic/commands/EditSessionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditSessionCommand.java
@@ -11,6 +11,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_RECUR;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SESSION_TYPE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STARTTIME;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -103,6 +104,17 @@ public class EditSessionCommand extends Command {
         Session.SessionType type = editSessionDescriptor.getSessionType().orElse(sessionToEdit.getSessionType());
         String description = editSessionDescriptor.getDescription().orElse(sessionToEdit.getDescription());
 
+        // If date is not updated, reset the date to the original date.
+        // We need to do this because EditSessionCommandParser is not able to know that is the original date
+        // to use as default value, so an arbitrary default date is used.
+        if (!editSessionDescriptor.getIsDateChanged()) {
+            LocalDate originalDate = sessionToEdit.getDate();
+            startTime = LocalDateTime.of(originalDate.getYear(), originalDate.getMonth(), originalDate.getDayOfMonth(),
+                    startTime.getHour(), startTime.getMinute(), startTime.getSecond());
+            endTime = LocalDateTime.of(originalDate.getYear(), originalDate.getMonth(), originalDate.getDayOfMonth(),
+                    endTime.getHour(), endTime.getMinute(), endTime.getSecond());
+        }
+
         return new Session(startTime, endTime, type, isRecurring, moduleCode, description);
     }
 
@@ -131,6 +143,7 @@ public class EditSessionCommand extends Command {
     public static class EditSessionDescriptor {
         private LocalDateTime newStartTime;
         private LocalDateTime newEndTime;
+        private boolean isDateChanged;
         private boolean isRecurring;
         private String moduleCode;
         private Session.SessionType newSessionType;
@@ -150,6 +163,7 @@ public class EditSessionCommand extends Command {
             setModuleCode(toCopy.moduleCode);
             setSessionType(toCopy.newSessionType);
             setDescription(toCopy.newDescription);
+            this.isDateChanged = toCopy.isDateChanged;
         }
 
         /**
@@ -181,6 +195,14 @@ public class EditSessionCommand extends Command {
 
         public boolean getIsRecurring() {
             return this.isRecurring;
+        }
+
+        public void setIsDateChanged(boolean isChanged) {
+            this.isDateChanged = isChanged;
+        }
+
+        public boolean getIsDateChanged() {
+            return this.isDateChanged;
         }
 
         public void setModuleCode(String moduleCode) {

--- a/src/main/java/seedu/address/logic/commands/EditSessionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditSessionCommand.java
@@ -182,7 +182,7 @@ public class EditSessionCommand extends Command {
         }
 
         public void setEndTime(LocalDateTime endTime) {
-            this.newEndTime = newEndTime;
+            this.newEndTime = endTime;
         }
 
         public Optional<LocalDateTime> getEndTime() {

--- a/src/main/java/seedu/address/logic/commands/EditSessionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditSessionCommand.java
@@ -1,0 +1,231 @@
+package seedu.address.logic.commands;
+
+// import static java.util.Objects.requireNonNull;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ENDTIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MOD_CODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTES;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_RECUR;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SESSION_TYPE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STARTTIME;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.CollectionUtil;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.session.Session;
+
+/**
+ * Edits the details of an existing session in TAT.
+ */
+public class EditSessionCommand extends Command {
+
+    public static final String COMMAND_WORD = String.format("%s %s", CommandWords.SESSION, CommandWords.EDIT_MODEL);
+
+    /* Example message usage. */
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits an existing session in TA-Tracker."
+            + "Parameters: "
+            + "index"
+            + "[" + PREFIX_STARTTIME + "START] "
+            + "[" + PREFIX_ENDTIME + "END] "
+            + "[" + PREFIX_DATE + "DATE] "
+            + "[" + PREFIX_RECUR + "] "
+            + "[" + PREFIX_MOD_CODE + "MOD_CODE] "
+            + "[" + PREFIX_SESSION_TYPE + "SESSION_TYPE] "
+            + "[" + PREFIX_NOTES + "NOTES] "
+            + "Example: " + COMMAND_WORD + " 2" + PREFIX_DATE + "20-02-2020 ";
+
+    public static final String MESSAGE_SUCCESS = "Session updated: %1$s";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+
+    private final Index index;
+    private final EditSessionCommand.EditSessionDescriptor editSessionDescriptor;
+
+    /**
+     * @param index                 of the session in the filtered session list to edit
+     * @param editSessionDescriptor details to edit the session with
+     */
+    public EditSessionCommand(Index index, EditSessionCommand.EditSessionDescriptor editSessionDescriptor) {
+        requireNonNull(index);
+        requireNonNull(editSessionDescriptor);
+
+        this.index = index;
+        this.editSessionDescriptor = new EditSessionCommand.EditSessionDescriptor(editSessionDescriptor);
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        List<Session> lastShownList = model.getFilteredSessionList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_SESSION_DISPLAYED_INDEX);
+        }
+
+        Session sessionToEdit = lastShownList.get(index.getZeroBased());
+        Session editedSession = createEditedSession(sessionToEdit, editSessionDescriptor);
+
+        // Session does not have an unique identifier like students/modules, and as such checking if
+        // the two objects are the same should not be done based on their field values.
+        // In this case, it is probably best to ignore no-edits.
+        /*
+        if (!sessionToEdit.isSamePerson(editedStudent) && model.hasPerson(editedStudent)) {
+            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+        }
+        */
+
+        model.setSession(sessionToEdit, editedSession);
+        model.updateFilteredSessionList(Model.PREDICATE_SHOW_ALL_SESSIONS);
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, editedSession));
+    }
+
+    /**
+     * Creates and returns a {@code Session} with the details of {@code sessionToEdit}
+     * edited with {@code editSessionDescriptor}.
+     */
+    private static Session createEditedSession(Session sessionToEdit,
+                                               EditSessionCommand.EditSessionDescriptor editSessionDescriptor) {
+        assert sessionToEdit != null;
+
+        LocalDateTime startTime = editSessionDescriptor.getStartTime().orElse(sessionToEdit.getStartDateTime());
+        LocalDateTime endTime = editSessionDescriptor.getEndTime().orElse(sessionToEdit.getEndDateTime());
+        boolean isRecurring = editSessionDescriptor.getIsRecurring();
+        String moduleCode = editSessionDescriptor.getModuleCode().orElse(sessionToEdit.getModuleCode());
+        Session.SessionType type = editSessionDescriptor.getSessionType().orElse(sessionToEdit.getSessionType());
+        String description = editSessionDescriptor.getDescription().orElse(sessionToEdit.getDescription());
+
+        return new Session(startTime, endTime, type, isRecurring, moduleCode, description);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EditSessionCommand)) {
+            return false;
+        }
+
+        // state check
+        EditSessionCommand e = (EditSessionCommand) other;
+        return index.equals(e.index)
+                && editSessionDescriptor.equals(e.editSessionDescriptor);
+    }
+
+    /**
+     * Stores the details to edit the student with. Each non-empty field value will replace the
+     * corresponding field value of the student.
+     */
+    public static class EditSessionDescriptor {
+        private LocalDateTime newStartTime;
+        private LocalDateTime newEndTime;
+        private boolean isRecurring;
+        private String moduleCode;
+        private Session.SessionType newSessionType;
+        private String newDescription;
+
+        public EditSessionDescriptor() {
+        }
+
+        /**
+         * Copy constructor.
+         * A defensive copy of {@code tags} is used internally.
+         */
+        public EditSessionDescriptor(EditSessionCommand.EditSessionDescriptor toCopy) {
+            setStartTime(toCopy.newStartTime);
+            setEndTime(toCopy.newEndTime);
+            setIsRecurring(toCopy.isRecurring);
+            setModuleCode(toCopy.moduleCode);
+            setSessionType(toCopy.newSessionType);
+            setDescription(toCopy.newDescription);
+        }
+
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(newStartTime, newEndTime, newSessionType, newDescription);
+        }
+
+        public void setStartTime(LocalDateTime startTime) {
+            this.newStartTime = startTime;
+        }
+
+        public Optional<LocalDateTime> getStartTime() {
+            return Optional.ofNullable(newStartTime);
+        }
+
+        public void setEndTime(LocalDateTime endTime) {
+            this.newEndTime = newEndTime;
+        }
+
+        public Optional<LocalDateTime> getEndTime() {
+            return Optional.ofNullable(newEndTime);
+        }
+
+        public void setIsRecurring(boolean isRecurring) {
+            this.isRecurring = isRecurring;
+        }
+
+        public boolean getIsRecurring() {
+            return this.isRecurring;
+        }
+
+        public void setModuleCode(String moduleCode) {
+            this.moduleCode = moduleCode;
+        }
+
+        public Optional<String> getModuleCode() {
+            return Optional.ofNullable(moduleCode);
+        }
+
+        public void setSessionType(Session.SessionType sessionType) {
+            this.newSessionType = sessionType;
+        }
+
+        public Optional<Session.SessionType> getSessionType() {
+            return Optional.ofNullable(newSessionType);
+        }
+
+        public void setDescription(String description) {
+            this.newDescription = description;
+        }
+
+        public Optional<String> getDescription() {
+            return Optional.ofNullable(newDescription);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            // short circuit if same object
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof EditSessionCommand.EditSessionDescriptor)) {
+                return false;
+            }
+
+            // state check
+            EditSessionCommand.EditSessionDescriptor e = (EditSessionCommand.EditSessionDescriptor) other;
+
+            return getStartTime().equals(e.getStartTime())
+                    && getEndTime().equals(e.getEndTime())
+                    && getSessionType().equals(e.getSessionType())
+                    && getDescription().equals(e.getDescription());
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -3,7 +3,6 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Collection;
 import java.util.HashSet;
@@ -12,6 +11,7 @@ import java.util.Set;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.session.Session;
 import seedu.address.model.student.Email;
 import seedu.address.model.student.Matric;
 import seedu.address.model.student.Name;
@@ -28,6 +28,7 @@ public class ParserUtil {
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
      * trimmed.
+     *
      * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
@@ -150,5 +151,28 @@ public class ParserUtil {
         requireNonNull(time);
         String trimmedTime = time.trim();
         return LocalTime.parse(trimmedTime);
+    }
+
+    /**
+     * Parses a {@code String sessionType} into a {@code Session.SessionType}
+     */
+    public static Session.SessionType parseSessionType(String sessionType) {
+        requireNonNull(sessionType);
+        String trimmedType = sessionType.trim();
+        assert (trimmedType.equals(trimmedType.toLowerCase()));
+        switch (trimmedType) {
+        case "tutorial":
+            return Session.SessionType.SESSION_TYPE_TUTORIAL;
+        case "lab":
+            return Session.SessionType.SESSION_TYPE_LAB;
+        case "consultation":
+            return Session.SessionType.SESSION_TYPE_CONSULTATION;
+        case "grading":
+            return Session.SessionType.SESSION_TYPE_GRADING;
+        case "preparation":
+            return Session.SessionType.SESSION_TYPE_PREPARATION;
+        default:
+            return Session.SessionType.SESSION_TYPE_OTHER;
+        }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,6 +2,9 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -131,4 +134,21 @@ public class ParserUtil {
         return trimmedValue;
     }
 
+    /**
+     * Parses a {@code String date} into a {@code LocalDate}
+     */
+    public static LocalDate parseDate(String date) {
+        requireNonNull(date);
+        String trimmedDate = date.trim();
+        return LocalDate.parse(trimmedDate);
+    }
+
+    /**
+     * Parses a {@code String time} into a {@code LocalTime}
+     */
+    public static LocalTime parseTime(String time) {
+        requireNonNull(time);
+        String trimmedTime = time.trim();
+        return LocalTime.parse(trimmedTime);
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/SessionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SessionCommandParser.java
@@ -1,0 +1,59 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandWords;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses user input into commands that interact with Session model.
+ */
+public class SessionCommandParser {
+
+    /**
+     * Used for initial separation of command word and args.
+     */
+    private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
+
+    private static final String UNIMPLEMENTED_CODE_FORMAT = "%s not yet implemented!";
+
+    /**
+     * Parses user input into command for execution.
+     *
+     * @param userInput full user input string
+     * @return the command based on the user input
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public Command parseCommand(String userInput) throws ParseException {
+        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
+        if (!matcher.matches()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+        }
+
+        final String commandWord = matcher.group("commandWord");
+        final String arguments = matcher.group("arguments");
+        switch (commandWord) {
+
+        case CommandWords.ADD_MODEL:
+            // return new AddSessionCommandParser().parse(arguments);
+            throw new ParseException(String.format(UNIMPLEMENTED_CODE_FORMAT, "Add session commands"));
+
+        case CommandWords.DELETE_MODEL:
+            // return new DeleteSessionCommandParser().parse(arguments);
+            throw new ParseException(String.format(UNIMPLEMENTED_CODE_FORMAT, "Delete session commands"));
+
+        case CommandWords.EDIT_MODEL:
+            // return new EditSessionCommandParser().parse(arguments);
+            throw new ParseException(String.format(UNIMPLEMENTED_CODE_FORMAT, "Edit session commands"));
+
+        default:
+            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/TaTrackerParser.java
+++ b/src/main/java/seedu/address/logic/parser/TaTrackerParser.java
@@ -13,6 +13,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.logic.parser.session.SessionCommandParser;
 
 /**
  * Parses user input.
@@ -54,8 +55,7 @@ public class TaTrackerParser {
             throw new ParseException(String.format(UNIMPLEMENTED_CODE_FORMAT, "Group commands"));
 
         case CommandWords.SESSION:
-            // return new SessionCommandParser().parseCommand(arguments);
-            throw new ParseException(String.format(UNIMPLEMENTED_CODE_FORMAT, "Session commands"));
+            return new SessionCommandParser().parseCommand(arguments);
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/session/EditSessionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/session/EditSessionCommandParser.java
@@ -1,0 +1,89 @@
+package seedu.address.logic.parser.session;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ENDTIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MOD_CODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTES;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_RECUR;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SESSION_TYPE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STARTTIME;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.stream.Stream;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.EditSessionCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.Prefix;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new EditSessionCommand object
+ */
+public class EditSessionCommandParser implements Parser<EditSessionCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the EditSessionCommand
+     * and returns an AddSessionCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public EditSessionCommand parse(String args) throws ParseException {
+        Index index = ParserUtil.parseIndex(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_STARTTIME, PREFIX_ENDTIME,
+                PREFIX_DATE, PREFIX_RECUR, PREFIX_MOD_CODE, PREFIX_SESSION_TYPE, PREFIX_NOTES);
+
+        LocalDate date = LocalDate.now(); // Arbitrary default value. Will be overwritten by EditSessionCommand
+        EditSessionCommand.EditSessionDescriptor editSessionDescriptor = new EditSessionCommand.EditSessionDescriptor();
+
+        if (argMultimap.getValue(PREFIX_DATE).isPresent()) {
+            date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
+            editSessionDescriptor.setIsDateChanged(true);
+        }
+
+        if (argMultimap.getValue(PREFIX_STARTTIME).isPresent()) {
+            LocalTime startTime = ParserUtil.parseTime(argMultimap.getValue(PREFIX_STARTTIME).get());
+            editSessionDescriptor.setStartTime(LocalDateTime.of(date.getYear(), date.getMonth(), date.getDayOfMonth(),
+                    startTime.getHour(), startTime.getMinute(), startTime.getSecond()));
+        }
+
+        if (argMultimap.getValue(PREFIX_ENDTIME).isPresent()) {
+            LocalTime endTime = ParserUtil.parseTime(argMultimap.getValue(PREFIX_ENDTIME).get());
+            editSessionDescriptor.setEndTime(LocalDateTime.of(date.getYear(), date.getMonth(), date.getDayOfMonth(),
+                    endTime.getHour(), endTime.getMinute(), endTime.getSecond()));
+        }
+
+        if (argMultimap.getValue(PREFIX_RECUR).isPresent()) {
+            editSessionDescriptor.setIsRecurring(argMultimap.getValue(PREFIX_RECUR).isPresent());
+        }
+
+        if (argMultimap.getValue(PREFIX_MOD_CODE).isPresent()) {
+            editSessionDescriptor.setModuleCode(ParserUtil.parseValue(argMultimap.getValue(PREFIX_MOD_CODE).get()));
+        }
+
+        if (argMultimap.getValue(PREFIX_SESSION_TYPE).isPresent()) {
+            editSessionDescriptor.setSessionType(
+                    ParserUtil.parseSessionType(argMultimap.getValue(PREFIX_SESSION_TYPE).get()));
+        }
+
+        if (argMultimap.getValue(PREFIX_NOTES).isPresent()) {
+            editSessionDescriptor.setDescription(ParserUtil.parseValue(argMultimap.getValue(PREFIX_NOTES).get()));
+        }
+
+        return new EditSessionCommand(index, editSessionDescriptor);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/session/SessionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/session/SessionCommandParser.java
@@ -1,4 +1,4 @@
-package seedu.address.logic.parser;
+package seedu.address.logic.parser.session;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;

--- a/src/main/java/seedu/address/model/session/Session.java
+++ b/src/main/java/seedu/address/model/session/Session.java
@@ -26,6 +26,8 @@ public class Session {
 
     private LocalDateTime startDateTime;
     private LocalDateTime endDateTime;
+    private boolean isRecurring;
+    private String moduleCode;
     private SessionType type;
     private String description;
 
@@ -33,7 +35,7 @@ public class Session {
      * Constructs a Session object.
      * The session's end time should be strictly after the session's start time.
      */
-    public Session(LocalDateTime start, LocalDateTime end, SessionType type,
+    public Session(LocalDateTime start, LocalDateTime end, SessionType type, boolean isRecurring, String moduleCode,
                    String description) throws IllegalArgumentException {
 
         if (start.compareTo(end) > 0) {
@@ -42,6 +44,8 @@ public class Session {
 
         this.startDateTime = start;
         this.endDateTime = end;
+        this.isRecurring = isRecurring;
+        this.moduleCode = moduleCode;
         this.type = type;
         this.description = description;
     }
@@ -73,6 +77,20 @@ public class Session {
      */
     public LocalDateTime getEndDateTime() {
         return this.endDateTime;
+    }
+
+    /**
+     * Returns true if session will recur every week; false otherwise.
+     */
+    public boolean getIsRecurring() {
+        return this.isRecurring;
+    }
+
+    /**
+     * Returns the module code associated with this session.
+     */
+    public String getModuleCode() {
+        return this.moduleCode;
     }
 
     /**

--- a/src/test/java/seedu/address/model/session/InvalidStartEndTimeTest.java
+++ b/src/test/java/seedu/address/model/session/InvalidStartEndTimeTest.java
@@ -14,6 +14,6 @@ public class InvalidStartEndTimeTest {
         LocalDateTime startTime = LocalDateTime.of(2020, 01, 01, 14, 00, 00);
         LocalDateTime endTime = startTime.minus(1, ChronoUnit.HOURS);
         assertThrows(IllegalArgumentException.class, () -> new Session(startTime, endTime,
-                Session.SessionType.SESSION_TYPE_OTHER, ""));
+                Session.SessionType.SESSION_TYPE_OTHER, false, "CS2103/T", "Description"));
     }
 }


### PR DESCRIPTION
## Summary

- Added `SessionCommandParser`
- Added `EditSessionCommandParser`
- Added `EditSessionCommand`

The edit session command has been integrated into `TaTrackerParser` and should be completely functional when this PR is merged.

### Changes to the Session model
There are changes to the Session model in this PR. Namely, the public constructor has been updated:
```java
public Session(
    LocalDateTime start,
    LocalDateTime end,
    SessionType type,
    boolean isRecurring,      // Newly added
    String moduleCode,        // Newly added
    String description
) ...
```
@chuayijing this may or may not require updates to what you were working on previously. 

### Note
`EditSessionCommand` has been cherry-picked from #103 as it is a dependency to complete `EditSessionCommandParser`. #103 is now obsolete.

