### PR TITLE
Fix session commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddSessionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddSessionCommand.java
@@ -18,7 +18,7 @@ import seedu.address.model.session.Session;
  */
 public class AddSessionCommand extends Command {
 
-    public static final String COMMAND_WORD = "Session";
+    public static final String COMMAND_WORD = CommandWords.SESSION + " " + CommandWords.ADD_MODEL;
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a session in TA-Tracker. "
             + "Parameters: "

--- a/src/main/java/seedu/address/logic/commands/AddSessionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddSessionCommand.java
@@ -4,6 +4,9 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ENDTIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MOD_CODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTES;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_RECUR;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SESSION_TYPE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STARTTIME;
 
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -17,17 +20,22 @@ public class AddSessionCommand extends Command {
 
     public static final String COMMAND_WORD = "Session";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a session to the TATracker. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a session in TA-Tracker. "
             + "Parameters: "
-            + PREFIX_STARTTIME + "START TIME "
-            + PREFIX_ENDTIME + "END TIME "
-            + PREFIX_DATE + "DATE "
-            + PREFIX_MOD_CODE + "MODULE CODE"
+            + "[" + PREFIX_STARTTIME + "START] "
+            + "[" + PREFIX_ENDTIME + "END] "
+            + "[" + PREFIX_DATE + "DATE] "
+            + "[" + PREFIX_RECUR + "RECURS] "
+            + "[" + PREFIX_MOD_CODE + "MOD_CODE] "
+            + "[" + PREFIX_SESSION_TYPE + "SESSION_TYPE] "
+            + "[" + PREFIX_NOTES + "NOTES] "
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_STARTTIME + "14:00 "
-            + PREFIX_ENDTIME + "END 16:00 "
+            + PREFIX_ENDTIME + "16:00 "
             + PREFIX_DATE + "19-02-2020 "
-            + PREFIX_MOD_CODE + "CS2103T";
+            + PREFIX_MOD_CODE + "CS2103T "
+            + PREFIX_SESSION_TYPE + "tutorial "
+            + PREFIX_NOTES + "Location: PLAB 04";
 
     public static final String MESSAGE_SUCCESS = "New session added: %1$s";
     public static final String MESSAGE_DUPLICATE_SESSION = "This session already exists in the address book";

--- a/src/main/java/seedu/address/logic/commands/EditSessionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditSessionCommand.java
@@ -31,9 +31,9 @@ public class EditSessionCommand extends Command {
     public static final String COMMAND_WORD = String.format("%s %s", CommandWords.SESSION, CommandWords.EDIT_MODEL);
 
     /* Example message usage. */
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits an existing session in TA-Tracker."
-            + "Parameters: "
-            + "index"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits an existing session in TA-Tracker. "
+            + "Existing values will be overwritten by the input values.\n"
+            + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_STARTTIME + "START] "
             + "[" + PREFIX_ENDTIME + "END] "
             + "[" + PREFIX_DATE + "DATE] "
@@ -41,7 +41,8 @@ public class EditSessionCommand extends Command {
             + "[" + PREFIX_MOD_CODE + "MOD_CODE] "
             + "[" + PREFIX_SESSION_TYPE + "SESSION_TYPE] "
             + "[" + PREFIX_NOTES + "NOTES] "
-            + "Example: " + COMMAND_WORD + " 2" + PREFIX_DATE + "20-02-2020 ";
+            + "Example: " + COMMAND_WORD + " 2 "
+            + PREFIX_DATE + "20-02-2020 ";
 
     public static final String MESSAGE_SUCCESS = "Session updated: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -14,7 +14,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_STARTTIME = new Prefix("s/");
     public static final Prefix PREFIX_ENDTIME = new Prefix("e/");
     public static final Prefix PREFIX_DATE = new Prefix("d/");
-    public static final Prefix PREFIX_RECUR = new Prefix("[-r]");
+    public static final Prefix PREFIX_RECUR = new Prefix("-r");
     public static final Prefix PREFIX_MOD_CODE = new Prefix("m/");
     public static final Prefix PREFIX_SESSION_TYPE = new Prefix("t/");
     public static final Prefix PREFIX_NOTES = new Prefix("n/");

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -163,17 +163,17 @@ public class ParserUtil {
         assert (trimmedType.equals(trimmedType.toLowerCase()));
         switch (trimmedType) {
         case "tutorial":
-            return Session.SessionType.SESSION_TYPE_TUTORIAL;
+            return Session.SessionType.TUTORIAL;
         case "lab":
-            return Session.SessionType.SESSION_TYPE_LAB;
+            return Session.SessionType.LAB;
         case "consultation":
-            return Session.SessionType.SESSION_TYPE_CONSULTATION;
+            return Session.SessionType.CONSULTATION;
         case "grading":
-            return Session.SessionType.SESSION_TYPE_GRADING;
+            return Session.SessionType.GRADING;
         case "preparation":
-            return Session.SessionType.SESSION_TYPE_PREPARATION;
+            return Session.SessionType.PREPARATION;
         default:
-            return Session.SessionType.SESSION_TYPE_OTHER;
+            return Session.SessionType.OTHER;
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -28,6 +28,8 @@ public class ParserUtil {
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
 
     private static final String MESSAGE_INVALID_DATE = "Dates should be in yyyy-MM-dd format";
+    private static final String MESSAGE_INVALID_TIME = "Times should be in HH:mm format";
+
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
      * trimmed.
@@ -155,11 +157,17 @@ public class ParserUtil {
 
     /**
      * Parses a {@code String time} into a {@code LocalTime}
+     *
+     * @throws ParseException if the given {@code time} is invalid.
      */
-    public static LocalTime parseTime(String time) {
+    public static LocalTime parseTime(String time) throws ParseException {
         requireNonNull(time);
         String trimmedTime = time.trim();
-        return LocalTime.parse(trimmedTime);
+        try {
+            return LocalTime.parse(trimmedTime);
+        } catch (DateTimeParseException dtpe) {
+            throw new ParseException(MESSAGE_INVALID_TIME);
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.format.DateTimeParseException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -26,6 +27,7 @@ public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
 
+    private static final String MESSAGE_INVALID_DATE = "Dates should be in yyyy-MM-dd format";
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
      * trimmed.
@@ -138,11 +140,17 @@ public class ParserUtil {
 
     /**
      * Parses a {@code String date} into a {@code LocalDate}
+     *
+     * @throws ParseException if the given {@code date} is invalid.
      */
-    public static LocalDate parseDate(String date) {
+    public static LocalDate parseDate(String date) throws ParseException {
         requireNonNull(date);
         String trimmedDate = date.trim();
-        return LocalDate.parse(trimmedDate);
+        try {
+            return LocalDate.parse(trimmedDate);
+        } catch (DateTimeParseException dtpe) {
+            throw new ParseException(MESSAGE_INVALID_DATE);
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/SessionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SessionCommandParser.java
@@ -10,6 +10,7 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandWords;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.logic.parser.session.AddSessionCommandParser;
 import seedu.address.logic.parser.session.EditSessionCommandParser;
 
 /**
@@ -42,8 +43,7 @@ public class SessionCommandParser {
         switch (commandWord) {
 
         case CommandWords.ADD_MODEL:
-            // return new AddSessionCommandParser().parse(arguments);
-            throw new ParseException(String.format(UNIMPLEMENTED_CODE_FORMAT, "Add session commands"));
+            return new AddSessionCommandParser().parse(arguments);
 
         case CommandWords.DELETE_MODEL:
             // return new DeleteSessionCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/SessionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SessionCommandParser.java
@@ -51,7 +51,6 @@ public class SessionCommandParser {
 
         case CommandWords.EDIT_MODEL:
             return new EditSessionCommandParser().parse(arguments);
-            // throw new ParseException(String.format(UNIMPLEMENTED_CODE_FORMAT, "Edit session commands"));
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/session/AddSessionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/session/AddSessionCommandParser.java
@@ -21,6 +21,14 @@ import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.session.Session;
 
+/*
+ * === BUGS ===
+ * TODO: No error when end time is after start time.
+ *
+ * TODO: Sessions cannot have dates that are earlier than the current date.
+ *        Earlier dates are replaced by the current date.
+ */
+
 /**
  * Parses input arguments and creates a new AddSessionCommand object
  */

--- a/src/main/java/seedu/address/logic/parser/session/AddSessionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/session/AddSessionCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser.session;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ENDTIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MOD_CODE;
@@ -34,6 +35,10 @@ public class AddSessionCommandParser implements Parser<AddSessionCommand> {
     public AddSessionCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_STARTTIME, PREFIX_ENDTIME,
                 PREFIX_DATE, PREFIX_RECUR, PREFIX_MOD_CODE, PREFIX_SESSION_TYPE, PREFIX_NOTES);
+
+        if (!argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddSessionCommand.MESSAGE_USAGE));
+        }
 
         LocalDate date = LocalDate.now();
         Session sessionToAdd = new Session();

--- a/src/main/java/seedu/address/logic/parser/session/EditSessionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/session/EditSessionCommandParser.java
@@ -22,6 +22,14 @@ import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 
+/*
+ * === BUGS ===
+ * TODO: No error when end time is after start time.
+ *
+ * TODO: Sessions cannot have dates that are earlier than the current date.
+ *        Earlier dates are replaced by the current date.
+ */
+
 /**
  * Parses input arguments and creates a new EditSessionCommand object
  */

--- a/src/main/java/seedu/address/logic/parser/session/EditSessionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/session/EditSessionCommandParser.java
@@ -92,6 +92,11 @@ public class EditSessionCommandParser implements Parser<EditSessionCommand> {
             editSessionDescriptor.setDescription(ParserUtil.parseValue(argMultimap.getValue(PREFIX_NOTES).get()));
         }
 
+        // TODO: Check if editing should be allowed if there are no fields
+        if (!editSessionDescriptor.isAnyFieldEdited()) {
+            throw new ParseException(EditSessionCommand.MESSAGE_NOT_EDITED);
+        }
+
         return new EditSessionCommand(index, editSessionDescriptor);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/session/EditSessionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/session/EditSessionCommandParser.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.parser.session;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ENDTIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MOD_CODE;
@@ -32,13 +34,22 @@ public class EditSessionCommandParser implements Parser<EditSessionCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public EditSessionCommand parse(String args) throws ParseException {
-        Index index = ParserUtil.parseIndex(args);
+        requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_STARTTIME, PREFIX_ENDTIME,
                 PREFIX_DATE, PREFIX_RECUR, PREFIX_MOD_CODE, PREFIX_SESSION_TYPE, PREFIX_NOTES);
 
-        LocalDate date = LocalDate.now(); // Arbitrary default value. Will be overwritten by EditSessionCommand
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditSessionCommand.MESSAGE_USAGE),
+                    pe);
+        }
+
         EditSessionCommand.EditSessionDescriptor editSessionDescriptor = new EditSessionCommand.EditSessionDescriptor();
 
+        LocalDate date = LocalDate.now(); // Arbitrary default value. Will be overwritten by EditSessionCommand
         if (argMultimap.getValue(PREFIX_DATE).isPresent()) {
             date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
             editSessionDescriptor.setIsDateChanged(true);

--- a/src/main/java/seedu/address/model/session/Session.java
+++ b/src/main/java/seedu/address/model/session/Session.java
@@ -16,12 +16,12 @@ public class Session {
      * Example session types include: Tutorial, Grading, Consultation, etc.
      */
     public enum SessionType {
-        SESSION_TYPE_TUTORIAL,
-        SESSION_TYPE_LAB,
-        SESSION_TYPE_CONSULTATION,
-        SESSION_TYPE_GRADING,
-        SESSION_TYPE_PREPARATION,
-        SESSION_TYPE_OTHER
+        TUTORIAL,
+        LAB,
+        CONSULTATION,
+        GRADING,
+        PREPARATION,
+        OTHER
     }
 
     private LocalDateTime startDateTime;
@@ -40,7 +40,7 @@ public class Session {
         this.endDateTime = LocalDateTime.now();
         this.isRecurring = false;
         this.moduleCode = "";
-        this.type = SessionType.SESSION_TYPE_OTHER;
+        this.type = SessionType.OTHER;
         this.description = "Default Session";
     }
 

--- a/src/main/java/seedu/address/model/session/Session.java
+++ b/src/main/java/seedu/address/model/session/Session.java
@@ -3,6 +3,7 @@ package seedu.address.model.session;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * Represents a session in TAT.
@@ -10,6 +11,9 @@ import java.time.LocalDateTime;
  * Guarantees: Date, Start Time and End Time are not null.
  */
 public class Session {
+
+    /** For converting date times to strings. Example: "2020-03-03 14:00" */
+    private static final DateTimeFormatter FORMAT_DATE_TIME = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
 
     /**
      * Represents a session type. Session types follows the same specifications as the TSS.
@@ -167,6 +171,18 @@ public class Session {
      */
     public Duration getSessionDuration() {
         return Duration.between(this.startDateTime, this.endDateTime);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder builder = new StringBuilder();
+        builder.append("Type: ").append(type)
+                .append(" Start: ").append(startDateTime.format(FORMAT_DATE_TIME))
+                .append(" End: ").append(endDateTime.format(FORMAT_DATE_TIME))
+                .append(" Module Code: ").append(moduleCode)
+                .append(" Description: ").append(description)
+                .append(" Recurs: ").append(isRecurring);
+        return builder.toString();
     }
 
     /**

--- a/src/test/java/seedu/address/model/session/InvalidStartEndTimeTest.java
+++ b/src/test/java/seedu/address/model/session/InvalidStartEndTimeTest.java
@@ -14,6 +14,6 @@ public class InvalidStartEndTimeTest {
         LocalDateTime startTime = LocalDateTime.of(2020, 01, 01, 14, 00, 00);
         LocalDateTime endTime = startTime.minus(1, ChronoUnit.HOURS);
         assertThrows(IllegalArgumentException.class, () -> new Session(startTime, endTime,
-                Session.SessionType.SESSION_TYPE_OTHER, false, "CS2103/T", "Description"));
+                Session.SessionType.OTHER, false, "CS2103/T", "Description"));
     }
 }


### PR DESCRIPTION
# Summary

There were some issues when testing the session commands:

# Bugs
- #125 : Add session command accepts trailing characters 
- #126 : Usage message of AddSessionCommand is never shown 
- #127 : EditSessionCommand executes when there are no fields provided
- #128 : Error when parsing an invalid date or time
- #129 : Error when parsing an invalid index in edit session command

# Fixes and Suggestions
#125 , #126 : Fixed by ensuring no trailing characters. However, an alternative is to make the start time a compulsory prefix.

#127 : Fixed by ensuring at least one field is being edited. However this conflicts with a comment in EditSessionCommandParser by @Eclmist.

#128 , #129 : Fixed by raising a ParseException.