### PR TITLE
Fix isSameStudent comparison

### DIFF
--- a/src/main/java/tatracker/model/student/Student.java
+++ b/src/main/java/tatracker/model/student/Student.java
@@ -77,10 +77,7 @@ public class Student {
         if (otherStudent == this) {
             return true;
         }
-
-        return otherStudent != null
-                && otherStudent.getName().equals(getName())
-                && otherStudent.getMatric().equals(getMatric());
+        return otherStudent != null && otherStudent.getMatric().equals(getMatric());
     }
 
     /**

--- a/src/main/java/tatracker/storage/JsonAdaptedGroup.java
+++ b/src/main/java/tatracker/storage/JsonAdaptedGroup.java
@@ -1,7 +1,9 @@
 package tatracker.storage;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -10,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import tatracker.commons.exceptions.IllegalValueException;
 import tatracker.model.group.Group;
 import tatracker.model.group.GroupType;
+import tatracker.model.student.Matric;
 import tatracker.model.student.Student;
 
 /**
@@ -69,20 +72,19 @@ class JsonAdaptedGroup {
         final GroupType modelGroupType = GroupType.valueOf(type);
 
         // ==== Students ====
-        final List<Student> modelStudents = new ArrayList<>();
+        final Map<Matric, Student> modelStudents = new HashMap<>();
         for (JsonAdaptedStudent jsonAdaptedStudent : students) {
             Student student = jsonAdaptedStudent.toModelType();
-            if (modelStudents.contains(student)) {
-                throw new IllegalArgumentException(MESSAGE_DUPLICATE_STUDENTS);
+            if (modelStudents.containsKey(student.getMatric())) {
+                throw new IllegalValueException(MESSAGE_DUPLICATE_STUDENTS);
             }
-            modelStudents.add(student);
+            modelStudents.put(student.getMatric(), student);
         }
 
         // ==== Build ====
         Group group = new Group(id, modelGroupType);
-        modelStudents.forEach(group::addStudent);
+        modelStudents.forEach((matric, student) -> group.addStudent(student));
 
         return group;
     }
-
 }

--- a/src/main/java/tatracker/storage/JsonAdaptedModule.java
+++ b/src/main/java/tatracker/storage/JsonAdaptedModule.java
@@ -79,7 +79,7 @@ class JsonAdaptedModule {
         for (JsonAdaptedSession jsonAdaptedSession : sessions) {
             Session doneSession = jsonAdaptedSession.toModelType();
             if (modelDoneSessions.contains(doneSession)) {
-                throw new IllegalArgumentException(MESSAGE_DUPLICATE_SESSIONS);
+                throw new IllegalValueException(MESSAGE_DUPLICATE_SESSIONS);
             }
             modelDoneSessions.add(doneSession);
         }
@@ -89,7 +89,7 @@ class JsonAdaptedModule {
         for (JsonAdaptedGroup jsonAdaptedGroup : groups) {
             Group group = jsonAdaptedGroup.toModelType();
             if (modelGroups.contains(group)) {
-                throw new IllegalArgumentException(MESSAGE_DUPLICATE_GROUPS);
+                throw new IllegalValueException(MESSAGE_DUPLICATE_GROUPS);
             }
             modelGroups.add(group);
         }

--- a/src/main/java/tatracker/storage/JsonSerializableTaTracker.java
+++ b/src/main/java/tatracker/storage/JsonSerializableTaTracker.java
@@ -64,7 +64,7 @@ class JsonSerializableTaTracker {
         for (JsonAdaptedSession jsonAdaptedSession : sessions) {
             Session session = jsonAdaptedSession.toModelType();
             if (modelSessions.contains(session)) {
-                throw new IllegalArgumentException(MESSAGE_DUPLICATE_SESSIONS);
+                throw new IllegalValueException(MESSAGE_DUPLICATE_SESSIONS);
             }
             modelSessions.add(session);
         }
@@ -74,7 +74,7 @@ class JsonSerializableTaTracker {
         for (JsonAdaptedModule jsonAdaptedModule : modules) {
             Module module = jsonAdaptedModule.toModelType();
             if (modelModules.contains(module)) {
-                throw new IllegalArgumentException(MESSAGE_DUPLICATE_MODULES);
+                throw new IllegalValueException(MESSAGE_DUPLICATE_MODULES);
             }
             modelModules.add(module);
         }

--- a/src/test/java/tatracker/model/student/StudentTest.java
+++ b/src/test/java/tatracker/model/student/StudentTest.java
@@ -1,5 +1,9 @@
 package tatracker.model.student;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static tatracker.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static tatracker.logic.commands.CommandTestUtil.VALID_MATRIC_BOB;
 import static tatracker.logic.commands.CommandTestUtil.VALID_NAME_BOB;
@@ -10,7 +14,6 @@ import static tatracker.testutil.Assert.assertThrows;
 import static tatracker.testutil.TypicalStudents.ALICE;
 import static tatracker.testutil.TypicalStudents.BOB;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import tatracker.testutil.StudentBuilder;
@@ -26,10 +29,10 @@ public class StudentTest {
     @Test
     public void isSameStudent() {
         // same object -> returns true
-        Assertions.assertTrue(ALICE.isSameStudent(ALICE));
+        assertTrue(ALICE.isSameStudent(ALICE));
 
         // null -> returns false
-        Assertions.assertFalse(ALICE.isSameStudent(null));
+        assertFalse(ALICE.isSameStudent(null));
 
         // different optional fields -> returns true
         Student editedAlice = new StudentBuilder(ALICE)
@@ -37,56 +40,56 @@ public class StudentTest {
                 .withEmail(VALID_EMAIL_BOB)
                 .withRating(VALID_RATING_BOB)
                 .withTags(VALID_TAG_HUSBAND).build();
-        Assertions.assertTrue(ALICE.isSameStudent(editedAlice));
+        assertTrue(ALICE.isSameStudent(editedAlice));
 
         // different matric -> returns false
         editedAlice = new StudentBuilder(ALICE)
                 .withMatric(VALID_MATRIC_BOB).build();
-        Assertions.assertFalse(ALICE.isSameStudent(editedAlice));
+        assertFalse(ALICE.isSameStudent(editedAlice));
 
-        // different name -> returns false
+        // different name -> returns true
         editedAlice = new StudentBuilder(ALICE)
                 .withName(VALID_NAME_BOB).build();
-        Assertions.assertFalse(ALICE.isSameStudent(editedAlice));
+        assertTrue(ALICE.isSameStudent(editedAlice));
     }
 
     @Test
     public void equals() {
         // same values -> returns true
         Student aliceCopy = new StudentBuilder(ALICE).build();
-        Assertions.assertTrue(ALICE.equals(aliceCopy));
+        assertEquals(ALICE, aliceCopy);
 
         // same object -> returns true
-        Assertions.assertTrue(ALICE.equals(ALICE));
+        assertEquals(ALICE, ALICE);
 
         // null -> returns false
-        Assertions.assertFalse(ALICE.equals(null));
+        assertNotEquals(ALICE, null);
 
         // different type -> returns false
-        Assertions.assertFalse(ALICE.equals(5));
+        assertNotEquals(ALICE, 5);
 
         // different student -> returns false
-        Assertions.assertFalse(ALICE.equals(BOB));
+        assertNotEquals(ALICE, BOB);
 
         // different name -> returns false
         Student editedAlice = new StudentBuilder(ALICE)
                 .withName(VALID_NAME_BOB).build();
-        Assertions.assertFalse(ALICE.equals(editedAlice));
+        assertNotEquals(ALICE, editedAlice);
 
         // different phone -> returns false
         editedAlice = new StudentBuilder(ALICE).withPhone(VALID_PHONE_BOB).build();
-        Assertions.assertFalse(ALICE.equals(editedAlice));
+        assertNotEquals(ALICE, editedAlice);
 
         // different email -> returns false
         editedAlice = new StudentBuilder(ALICE).withEmail(VALID_EMAIL_BOB).build();
-        Assertions.assertFalse(ALICE.equals(editedAlice));
+        assertNotEquals(ALICE, editedAlice);
 
         // different matric -> returns false
         editedAlice = new StudentBuilder(ALICE).withMatric(VALID_MATRIC_BOB).build();
-        Assertions.assertFalse(ALICE.equals(editedAlice));
+        assertNotEquals(ALICE, editedAlice);
 
         // different tags -> returns false
         editedAlice = new StudentBuilder(ALICE).withTags(VALID_TAG_HUSBAND).build();
-        Assertions.assertFalse(ALICE.equals(editedAlice));
+        assertNotEquals(ALICE, editedAlice);
     }
 }


### PR DESCRIPTION
Duplicate students could be added if they had the same Matric but different Names. Now, only one student can have the same Matric number.